### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/zinedistro/zinedistro.png?label=ready&title=Ready)](https://waffle.io/zinedistro/zinedistro)
 # A Zine Distro in a Box
 
 [![Build Status](https://travis-ci.org/zinedistro/zinedistro.svg?branch=master)](https://travis-ci.org/zinedistro/zinedistro)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/zinedistro/zinedistro

This was requested by a real person (user faun) on waffle.io, we're not trying to spam you.