### PR TITLE
Add WEB_TIMEOUT_IN_SECONDS env var to set timeout

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,1 @@
+Rack::Timeout.timeout = ENV['WEB_TIMEOUT_IN_SECONDS'].to_i || 5


### PR DESCRIPTION
Manually set the threshold at which Rack::Timeout raises a timeout
exception if WEB_TIMEOUT_IN_SECONDS is set.

NB: Timing out is inherently unsafe for multi-threaded code:
https://github.com/heroku/rack-timeout#timing-out-inherently-unsafe