### PR TITLE
Add ETag headers for public resources

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -2,9 +2,11 @@
 class AuthorsController < ApplicationController
   def index
     @authors = Author.published.order_by_name
+    fresh_when last_modified: @authors.maximum(:updated_at), public: true
   end
 
   def show
     @author = Author.find_published(params[:id])
+    fresh_when last_modified: @author.updated_at, public: true
   end
 end

--- a/app/controllers/zines_controller.rb
+++ b/app/controllers/zines_controller.rb
@@ -3,11 +3,13 @@ class ZinesController < ApplicationController
   def index
     @zines = Zine.catalog_with_authors.page(ZineParams.index(params)[:page]).decorate
     @most_recent = Zine.most_recently_published_date
+    fresh_when last_modified: @most_recent, public: true
   end
 
   def show
     @zine = Zine.find_published_with_authors(ZineParams.show(params)).decorate
     not_found unless @zine
+    fresh_when last_modified: @zine.updated_at, public: true
   end
 
   # strong parameters for zine


### PR DESCRIPTION
This allows the zines and authors to be cacheable via a CDN (or other reverse proxy)