### PR TITLE
Only raise exceptions in development and test

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -86,8 +86,5 @@ module ZineDistro
     # Don't suppress Active Record errors raised within after_rollback or
     # after_commit callbacks
     config.active_record.raise_in_transactional_callbacks = true
-
-    # Raise an exception on unpermitted parameters
-    config.action_controller.action_on_unpermitted_parameters = :raise
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,4 +48,7 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.rails_logger = true
   end
+
+  # Raise an exception on unpermitted parameters
+  config.action_controller.action_on_unpermitted_parameters = :raise
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,6 @@ Rails.application.configure do
     host: "localhost:#{ENV.fetch("$PORT", 3000)}"
   }
 
+  # Raise an exception on unpermitted parameters
+  config.action_controller.action_on_unpermitted_parameters = :raise
 end


### PR DESCRIPTION
Raising errors on unknown parameters in production is noisy and
potentially causes broken behavior.